### PR TITLE
Replace linpack with lapack

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ using an [active set method](https://en.wikipedia.org/wiki/Active-set_method). I
  - All obsolescent features (`goto`, etc) have been removed. It is now 100% standard compliant (Fortran 2018).
  - It makes use of derived-type and easy to use interfaces. The `qp_problem` class is used to defined the quadratic program and `solve` to compute its solution.
  - Calls to `blas` functions and subroutines now replace some hand-crafted implementations for improved performances.
+ - Calls to `lapack` subroutines now replace the original functionalities provided by [`linpack`](https://www.netlib.org/linpack/).
 
 
 ### Building QuadProg
@@ -53,7 +54,7 @@ QuadProg = { git="https://github.com/loiseaujc/QuadProg.git"}
 
 ### Dependencies
 
-The library requires some [`blas`](https://netlib.org/blas/) routines which are not included. You thus need to have it available on your system.
+The library requires some [`blas`](https://netlib.org/blas/) and [`lapack`](https://www.netlib.org/lapack/) routines which are not included. You thus need to have it available on your system.
 
 ### Example
 

--- a/src/QuadProg.f90
+++ b/src/QuadProg.f90
@@ -108,7 +108,7 @@ contains
       real(dp), intent(in)           :: P(:, :), q(:)
       real(dp), optional, intent(in) :: A(:, :), b(:)
       real(dp), optional, intent(in) :: C(:, :), d(:)
-      integer :: info
+      integer :: info, n
 
       prob%neq = 0; prob%ncons = 0
 
@@ -117,11 +117,11 @@ contains
       if (size(P, 1) /= size(q)) error stop "Matrix P and vector q have incompatible dimensions."
 
       !> Quadratic cost.
-      prob%P = P; prob%q = q
+      prob%P = P; prob%q = q; n = size(P, 1)
 
       !> Pre-factorize the symmetric positive definite matrix.
-      call dpofa(prob%P, size(P, 1), size(P, 2), info)
-      call dpori(prob%P, size(P, 1), size(P, 2))
+      call dpotrf("u", n, prob%P, n, info)
+      call dtrtri("u", "n", n, prob%P, n, info)
 
       !> Sanity checks for the equality constraints.
       if (present(A) .and. .not. present(b)) error stop "Right-hand side vector b for the equality constraints is missing."

--- a/src/QuadProg.f90
+++ b/src/QuadProg.f90
@@ -87,21 +87,6 @@ module QuadProg
       end subroutine
    end interface
 
-   interface
-      module subroutine dpofa(A, lda, n, info)
-         integer, intent(in) :: lda
-         real(dp), intent(out) :: A(lda, *)
-         integer, intent(in) :: n
-         integer, intent(out) :: info
-      end subroutine
-
-      module subroutine dpori(A, lda, n)
-         integer, intent(in) :: lda
-         real(dp), intent(out) :: A(lda, *)
-         integer, intent(in) :: n
-      end subroutine
-   end interface
-
 contains
 
    type(qp_problem) function initialize_qp_problem(P, q, A, b, C, d) result(prob)

--- a/src/quadprog/solvers.f90
+++ b/src/quadprog/solvers.f90
@@ -98,12 +98,12 @@ contains
 
    if (ierr == 0) then
       !> Matrix has not been factorized yet.
-      call dpofa(dmat, fddmat, n, info)   ! Cholesky factorization.
+      call dpotrf("u", fddmat, dmat, n, info)   ! Cholesky factorization.
       if (info /= 0) then
          ierr = 2; return
       end if
-      call dposl(dmat, fddmat, n, dvec)   ! Solve Ax = b with pre-computed Chol. fact.
-      call dpori(dmat, fddmat, n)         ! Compute inv(A) from pre-computed Chol. fact.
+      call dpotrs("u", fddmat, 1, dmat, n, dvec, n, info)   ! Solve Ax = b using Chol. fact.
+      call dtrtri("u", "n", fddmat, dmat, n, info) ! Compute inv(R) from Chol. fact.
    else
       !> Matrix has already been pre-factorized by calling dpofa and dpori.
       !> Multiply by inv(R).T

--- a/src/quadprog/solvers.f90
+++ b/src/quadprog/solvers.f90
@@ -556,31 +556,20 @@ contains
    !------------------------------------------------------------
    !-----     SOLVE UNCONSTRAINED QP AS STARTING POINT     -----
    !------------------------------------------------------------
-
    if (ierr == 0) then
       !> Matrix has not been factorized yet.
-      call dpofa(dmat, fddmat, n, info)   ! Cholesky factorization.
+      call dpotrf("u", fddmat, dmat, n, info)   ! Cholesky factorization.
       if (info /= 0) then
          ierr = 2; return
       end if
-      call dposl(dmat, fddmat, n, dvec)   ! Solve Ax = b with pre-computed Chol. fact.
-      call dpori(dmat, fddmat, n)         ! Compute inv(A) from pre-computed Chol. fact.
+      call dpotrs("u", fddmat, 1, dmat, n, dvec, n, info)   ! Solve Ax = b using Chol. fact.
+      call dtrtri("u", "n", fddmat, dmat, n, info) ! Compute inv(R) from Chol. fact.
    else
       !> Matrix has already been pre-factorized by calling dpofa and dpori.
-      !> Multiply by inv(R).T.
-      do j = 1, n
-         sol(j) = 0.d0
-         do i = 1, j
-            sol(j) = sol(j) + dmat(i, j)*dvec(i)
-         end do
-      end do
+      !> Multiply by inv(R).T
+      call dtrmv("u", "t", "n", n, dmat, n, dvec, 1)
       !> Multiply by inv(R).
-      do j = 1, n
-         dvec(j) = 0.d0
-         do i = j, n
-            dvec(j) = dvec(j) + dmat(j, i)*sol(i)
-         end do
-      end do
+      call dtrmv("u", "n", "n", n, dmat, n, dvec, 1)
    end if
 
    !> Book-keeping:
@@ -996,155 +985,4 @@ contains
    return
    end procedure qpgen1
 
-!     dpofa factors a double precision symmetric positive definite
-!     matrix.
-!     dpofa is usually called by dpoco, but it can be called
-!     directly with a saving in time if  rcond  is not needed.
-!     (time for dpoco) = (1 + 18/n)*(time for dpofa) .
-!     on entry
-!        a       double precision(lda, n)
-!                the symmetric matrix to be factored.  only the
-!                diagonal and upper triangle are used.
-!        lda     integer
-!                the leading dimension of the array  a .
-!        n       integer
-!                the order of the matrix  a .
-!     on return
-!        a       an upper triangular matrix  r  so that  a = trans(r)*r
-!                where  trans(r)  is the transpose.
-!                the strict lower triangle is unaltered.
-!                if  info .ne. 0 , the factorization is not complete.
-!        info    integer
-!                = 0  for normal return.
-!                = k  signals an error condition.  the leading minor
-!                     of order  k  is not positive definite.
-!     linpack.  this version dated 08/14/78 .
-!     cleve moler, university of new mexico, argonne national lab.
-   module procedure dpofa
-   real(dp) :: t, s, ddot
-   integer  :: j, k
-
-   do j = 1, n
-      info = j; s = 0.0_dp
-      do k = 1, j - 1
-         t = A(k, j) - ddot(k - 1, A(:k - 1, k), 1, A(:k - 1, j), 1)
-         t = t/A(k, k); A(k, j) = t; s = s + t*t
-      end do
-      s = A(j, j) - s
-      if (s <= 0.0_dp) return
-      A(j, j) = sqrt(s)
-   end do
-   info = 0
-   return
-   end procedure
-
-!     dpori computes the inverse of the factor of a
-!     double precision symmetric positive definite matrix
-!     using the factors computed by dpofa.
-!
-!     modification of dpodi by bat 05/11/95
-!
-!     on entry
-!
-!        a       double precision(lda, n)
-!                the output  a  from dpofa
-!
-!        lda     integer
-!                the leading dimension of the array  a .
-!
-!        n       integer
-!                the order of the matrix  a .
-!
-!     on return
-!
-!        a       if dpofa was used to factor  a  then
-!                dpodi produces the upper half of inverse(a) .
-!                elements of  a  below the diagonal are unchanged.
-!
-!     error condition
-!
-!        a division by zero will occur if the input factor contains
-!        a zero on the diagonal and the inverse is requested.
-!        it will not occur if the subroutines are called correctly
-!        and if dpoco or dpofa has set info .eq. 0 .
-!
-!     linpack.  this version dated 08/14/78 .
-!     cleve moler, university of new mexico, argonne national lab.
-!     modified by berwin a. turlach 05/11/95
-   module procedure dpori
-   real(dp) :: t
-   integer :: j, k
-
-   !> Compute the inverse.
-   do k = 1, n
-      A(k, k) = 1.0d0/A(k, k); t = -A(k, k)
-      call dscal(k - 1, t, A(:k - 1, k), 1)
-      do j = k + 1, n
-         t = A(k, j); A(k, j) = 0.0d0
-         A(:k, j) = A(:k, j) + t*A(:k, k)
-      end do
-   end do
-   return
-   end procedure
-
-!     dposl solves the double precision symmetric positive definite
-!     system a * x = b
-!     using the factors computed by dpoco or dpofa.
-!     on entry
-!        a       double precision(lda, n)
-!                the output from dpoco or dpofa.
-!        lda     integer
-!                the leading dimension of the array  a .
-!        n       integer
-!                the order of the matrix  a .
-!        b       double precision(n)
-!                the right hand side vector.
-!     on return
-!        b       the solution vector  x .
-!     error condition
-!        a division by zero will occur if the input factor contains
-!        a zero on the diagonal.  technically this indicates
-!        singularity but it is usually caused by improper subroutine
-!        arguments.  it will not occur if the subroutines are called
-!        correctly and  info .eq. 0 .
-!     to compute  inverse(a) * c  where  c  is a matrix
-!     with  p  columns
-!           call dpoco(a,lda,n,rcond,z,info)
-!           if (rcond is too small .or. info .ne. 0) go to ...
-!           do 10 j = 1, p
-!              call dposl(a,lda,n,c(1,j))
-!        10 continue
-!     linpack.  this version dated 08/14/78 .
-!     cleve moler, university of new mexico, argonne national lab.
-   pure subroutine dposl(A, lda, n, b)
-!      use quadprog_constants, only: dp
-      integer, intent(in)  :: lda
-  !! Leading dimension of the matrix A (i.e. number of rows).
-      integer, intent(in)  :: n
-  !! Number of columns of the matrix A.
-      real(dp), intent(in) :: A(lda, *)
-  !! Matrix A already factorized.
-      real(dp), intent(inout) :: b(*)
-  !! On entry, right-hand side vector.
-  !! On exit, solution vector.
-
-      !> Internal variables.
-      real(dp) :: t
-      integer  :: k, kb
-
-      ! Solve trans(r)*y = b
-      do k = 1, n
-         t = dot_product(A(:k - 1, k), b(:k - 1))
-         b(k) = (b(k) - t)/A(k, k)
-      end do
-
-      ! Solve r*x = y
-      do kb = 1, n
-         k = n + 1 - kb
-         b(k) = b(k)/A(k, k)
-         t = -b(k)
-         b(:k - 1) = t*A(:k - 1, k) + b(:k - 1)
-      end do
-      return
-   end subroutine dposl
 end submodule

--- a/test/problems.f90
+++ b/test/problems.f90
@@ -57,7 +57,7 @@ contains
       !> Get the constraints matrix and vector.
       allocate (G(1, 1), h(1)); G = 0.0_dp; h = 0.0_dp
       !> Solve the QP problem.
-      info = 1 ! P is already factorized when defining the QP.
+      info = 0 ! P is already factorized when defining the QP.
       call qpgen2(P, q, n, n, x, y, obj, G, h, n, ncons, neq, iact, nact, iter, work, info)
 
       !> Check QuadProg info message.


### PR DESCRIPTION
- Removed deps on linpack functions in qpgen2 with the corresponding lapack alternatives.
- Removed the linpack functions altogether.
- Added test for unconstrained QP with legacy solver.
